### PR TITLE
Yarn 1.0+ don't require "--"

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -89,7 +89,7 @@ yarn
 @task('generateAssets', ['on' => 'remote'])
 {{ logMessage("🌅  Generating assets...") }}
 cd {{ $newReleaseDir }};
-yarn run production -- --progress false
+yarn run production --progress false
 @endtask
 
 @task('updateSymlinks', ['on' => 'remote'])


### PR DESCRIPTION
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts